### PR TITLE
Fix broken import in pongo_helper.c

### DIFF
--- a/src/pongo/pongo_helper.c
+++ b/src/pongo/pongo_helper.c
@@ -2,7 +2,6 @@
 #include <pongo/shellcode.h>
 #include <pongo/pongo.h>
 #include <pongo/lz4/lz4hc.h>
-#include <sys/_types/_null.h>
 
 extern struct AchillesArgs args;
 


### PR DESCRIPTION
Related to #1

Remove unnecessary header file inclusion in `src/pongo/pongo_helper.c`.

* Remove the line `#include <sys/_types/_null.h>` at line 5 to fix compilation error on Linux.